### PR TITLE
Fix missing BYTES_PER_WRITE for pipeline write

### DIFF
--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -379,6 +379,7 @@ Status DBImpl::PipelinedWriteImpl(const WriteOptions& write_options,
     RecordTick(stats_, NUMBER_KEYS_WRITTEN, total_count);
     stats->AddDBStats(InternalStats::BYTES_WRITTEN, total_byte_size);
     RecordTick(stats_, BYTES_WRITTEN, total_byte_size);
+    MeasureTime(stats_, BYTES_PER_WRITE, total_byte_size);
 
     PERF_TIMER_STOP(write_pre_and_post_process_time);
 


### PR DESCRIPTION
Summary: Closes https://github.com/facebook/rocksdb/pull/2862

Differential Revision: D5805638

Pulled By: yiwu-arbug

fbshipit-source-id: 72d38c74395690023a719f400daff01527645a17