### PR TITLE
[Cherry-Pick] Fsync after writing global seq number in ExternalSstFileIngestionJob

### DIFF
--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -551,6 +551,9 @@ Status ExternalSstFileIngestionJob::AssignGlobalSeqnoForIngestedFile(
   PutFixed64(&seqno_val, seqno);
   status = rwfile->Write(file_to_ingest->global_seqno_offset, seqno_val);
   if (status.ok()) {
+    status = rwfile->Fsync();
+  }
+  if (status.ok()) {
     file_to_ingest->assigned_seqno = seqno;
   }
   return status;


### PR DESCRIPTION
Summary:
Fsync after writing global sequence number to the ingestion file in ExternalSstFileIngestionJob. Otherwise the file metadata could be incorrect.
Closes https://github.com/facebook/rocksdb/pull/3644

Differential Revision: D7373813

Pulled By: sagar0

fbshipit-source-id: 4da2c9e71a8beb5c08b4ac955f288ee1576358b8