### PR TITLE
Fix a leak in FilterBlockBuilder when adding prefix

### DIFF
--- a/table/block_based_filter_block.cc
+++ b/table/block_based_filter_block.cc
@@ -108,9 +108,9 @@ inline void BlockBasedFilterBlockBuilder::AddPrefix(const Slice& key) {
   Slice prefix = prefix_extractor_->Transform(key);
   // insert prefix only when it's different from the previous prefix.
   if (prev.size() == 0 || prefix != prev) {
-    AddKey(prefix);
     prev_prefix_start_ = entries_.size();
     prev_prefix_size_ = prefix.size();
+    AddKey(prefix);
   }
 }
 


### PR DESCRIPTION
Summary:
Our valgrind continuous test found an interesting leak which got introduced in #3614. We were adding the prefix key before saving the previous prefix start offset, due to which previous prefix offset is always incorrect. Fixed it by saving the the previous sate before adding the key.
Closes https://github.com/facebook/rocksdb/pull/3660

Differential Revision: D7418698

Pulled By: sagar0

fbshipit-source-id: 9933685f943cf2547ed5c553f490035a2fa785cf