### PR TITLE
Fix compile error on gcc 4.8.5

### DIFF
--- a/utilities/titandb/options.cc
+++ b/utilities/titandb/options.cc
@@ -1,5 +1,9 @@
 #include "utilities/titandb/options.h"
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 #include "rocksdb/convenience.h"


### PR DESCRIPTION
We should explicitly define `__STDC_FORMAT_MACROS` for old version gcc