### PR TITLE
Evict blob file handle from cache when it was deleted

### DIFF
--- a/utilities/titandb/version.cc
+++ b/utilities/titandb/version.cc
@@ -57,6 +57,18 @@ void BlobStorage::ComputeGCScore() {
             });
 }
 
+void BlobStorage::AddBlobFiles(
+    const std::map<uint64_t, std::shared_ptr<BlobFileMeta>>& files) {
+  files_.insert(files.begin(), files.end());
+}
+
+void BlobStorage::DeleteBlobFiles(const std::set<uint64_t>& files) {
+  for (const auto& f : files) {
+    files_.erase(f);
+    file_cache_->Evict(f);
+  }
+}
+
 Version::~Version() {
   assert(refs_ == 0);
 

--- a/utilities/titandb/version.h
+++ b/utilities/titandb/version.h
@@ -54,6 +54,10 @@ class BlobStorage {
 
   const TitanCFOptions& titan_cf_options() { return titan_cf_options_; }
 
+  void AddBlobFiles(
+      const std::map<uint64_t, std::shared_ptr<BlobFileMeta>>& files);
+  void DeleteBlobFiles(const std::set<uint64_t>& files);
+
  private:
   friend class Version;
   friend class VersionSet;

--- a/utilities/titandb/version_builder.cc
+++ b/utilities/titandb/version_builder.cc
@@ -42,10 +42,8 @@ std::shared_ptr<BlobStorage> VersionBuilder::Builder::Build() {
   }
 
   auto vs = std::make_shared<BlobStorage>(*base_.lock());
-  vs->files_.insert(added_files_.begin(), added_files_.end());
-  for (auto& file : deleted_files_) {
-    vs->files_.erase(file);
-  }
+  vs->AddBlobFiles(added_files_);
+  vs->DeleteBlobFiles(deleted_files_);
   vs->ComputeGCScore();
   return vs;
 }


### PR DESCRIPTION
The original implementation didn't evict blob file handle from cache when it was deleted such that the disk space will not be reclaimed as soon as possible.