### PR TITLE
adjust the order of getting snapshot and version

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -555,11 +555,10 @@ class DBImpl : public DB {
 
   const WriteController& write_controller() { return write_controller_; }
 
-  InternalIterator* NewInternalIterator(const ReadOptions&,
-                                        ColumnFamilyData* cfd,
-                                        SuperVersion* super_version,
-                                        Arena* arena,
-                                        RangeDelAggregator* range_del_agg);
+  InternalIterator* NewInternalIterator(
+      const ReadOptions&, ColumnFamilyData* cfd, SuperVersion* super_version,
+      Arena* arena, RangeDelAggregator* range_del_agg, SequenceNumber sequence,
+      bool is_user_sv = false);
 
   // hollow transactions shell used for recovery.
   // these will then be passed to TransactionDB so that

--- a/utilities/titandb/db_impl.cc
+++ b/utilities/titandb/db_impl.cc
@@ -417,7 +417,7 @@ Iterator* TitanDBImpl::NewIteratorImpl(
   }
   std::unique_ptr<ArenaWrappedDBIter> iter(db_impl_->NewIteratorImpl(
       options, cfd, snap->GetSequenceNumber(), nullptr /*read_callback*/,
-      true /*allow_blob*/, sv));
+      true /*allow_blob*/, true /*allow_refresh*/, sv));
   return new TitanDBIterator(options, storage.lock().get(), snapshot,
                              std::move(iter));
 }

--- a/utilities/titandb/db_impl.cc
+++ b/utilities/titandb/db_impl.cc
@@ -51,6 +51,8 @@ class TitanDBImpl::FileManager : public BlobFileManager {
       }
       if (!s.ok()) return s;
 
+      ROCKS_LOG_WARN(db_->db_options_.info_log, "Titan adding blob file [%llu]",
+                     file.first->file_number());
       edit.AddBlobFile(file.first);
     }
 

--- a/utilities/titandb/db_impl.cc
+++ b/utilities/titandb/db_impl.cc
@@ -445,12 +445,12 @@ const Snapshot* TitanDBImpl::GetSnapshot() {
   std::map<ColumnFamilyData*, SuperVersion*> svs;
   {
     MutexLock l(&mutex_);
-    current = vset_->current();
-    current->Ref();
     snapshot = db_->GetSnapshot();
     for (auto cfd : cfds_) {
       svs.emplace(cfd, db_impl_->GetReferencedSuperVersion(cfd));
     }
+    current = vset_->current();
+    current->Ref();
   }
   return new TitanSnapshot(current, snapshot, &svs);
 }

--- a/utilities/titandb/db_impl_gc.cc
+++ b/utilities/titandb/db_impl_gc.cc
@@ -103,6 +103,10 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer) {
 
     if (s.ok()) {
       s = blob_gc_job.Finish();
+      const Snapshot *snapshot = db_->GetSnapshot();
+      ROCKS_LOG_WARN(db_options_.info_log, "sequence number is %llu after gc job",
+        snapshot->GetSequenceNumber());
+      db_->ReleaseSnapshot(snapshot);
     }
 
     blob_gc->ReleaseGcFiles();

--- a/utilities/titandb/db_iter.h
+++ b/utilities/titandb/db_iter.h
@@ -139,9 +139,10 @@ class TitanDBIterator : public Iterator {
       // corresponding blob file has already been GCed out, so we
       // cannot abort here.
       if (status_.IsCorruption()) {
-        fprintf(stderr, "key:%s GetBlobValue err:%s\n",
+        fprintf(stderr, "key:%s GetBlobValue err:%s with sequence number:%lu \n",
                 iter_->key().ToString(true).c_str(),
-                status_.ToString().c_str());
+                status_.ToString().c_str(),
+                snap_->snapshot()->GetSequenceNumber());
         assert(false);
         return false;
       }

--- a/utilities/titandb/db_iter.h
+++ b/utilities/titandb/db_iter.h
@@ -142,7 +142,7 @@ class TitanDBIterator : public Iterator {
         fprintf(stderr, "key:%s GetBlobValue err:%s with sequence number:%lu \n",
                 iter_->key().ToString(true).c_str(),
                 status_.ToString().c_str(),
-                snap_->snapshot()->GetSequenceNumber());
+                options_.snapshot->GetSequenceNumber());
         assert(false);
         return false;
       }


### PR DESCRIPTION
note that
```rust
Status BlobGCJob::Finish() {
  Status s;
  {
    mutex_->Unlock();
    s = InstallOutputBlobFiles();
    if (s.ok()) s = RewriteValidKeyToLSM();
    mutex_->Lock();
  }
  ...
}
```
and
```rust
const Snapshot* TitanDBImpl::GetSnapshot() {
  Version* current;
  const Snapshot* snapshot;
  std::map<ColumnFamilyData*, SuperVersion*> svs;
  {
    MutexLock l(&mutex_);
    current = vset_->current();
    current->Ref();
    snapshot = db_->GetSnapshot();
    for (auto cfd : cfds_) {
      svs.emplace(cfd, db_impl_->GetReferencedSuperVersion(cfd));
    } 
  }
  return new TitanSnapshot(current, snapshot, &svs);
}
```

When we getting a snapshot and also doing gc in background, there may be a order that
```
   get-snapshot-thread                                     gc-thread
                |                                               |          
current = vset_->current()                                      | 
                |                                     InstallOutputBlobFiles()
                |                                               | 
                |                                     RewriteValidKeyToLSM() 
                |                                               | 
snapshot = db->GetSnapshot()                                    |          
                |                                               | 
```
In this case, we will get a version not including new blob files with a snapshot including updated LSM key. So it will panic because it can not find the new blob files based on the updated LSM key.


        