### PR TITLE
Fix Titan compatibility with rocksdb 5.18

### DIFF
--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -349,6 +349,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
        sizeof(std::shared_ptr<const SliceTransform>)},
       {offset_of(&ColumnFamilyOptions::table_factory),
        sizeof(std::shared_ptr<TableFactory>)},
+      {offset_of(&ColumnFamilyOptions::original_table_factory),
+       sizeof(std::shared_ptr<TableFactory>)},
       {offset_of(&ColumnFamilyOptions::cf_paths),
        sizeof(std::vector<DbPath>)},
   };

--- a/utilities/titandb/blob_file_iterator_test.cc
+++ b/utilities/titandb/blob_file_iterator_test.cc
@@ -57,7 +57,7 @@ class BlobFileIteratorTest : public testing::Test {
     {
       std::unique_ptr<WritableFile> f;
       ASSERT_OK(env_->NewWritableFile(file_name_, &f, env_options_));
-      writable_file_.reset(new WritableFileWriter(std::move(f), env_options_));
+      writable_file_.reset(new WritableFileWriter(std::move(f), file_name_, env_options_));
     }
     builder_.reset(new BlobFileBuilder(cf_options, writable_file_.get()));
   }

--- a/utilities/titandb/blob_file_reader.cc
+++ b/utilities/titandb/blob_file_reader.cc
@@ -107,7 +107,7 @@ Status BlobFileReader::Get(const ReadOptions& /*options*/,
 Status BlobFileReader::ReadRecord(const BlobHandle& handle, BlobRecord* record,
                                   OwnedSlice* buffer) {
   Slice blob;
-  std::unique_ptr<char[]> ubuf(new char[handle.size]);
+  CacheAllocationPtr ubuf(new char[handle.size]);
   TRY(file_->Read(handle.offset, handle.size, &blob, ubuf.get()));
   // something must be wrong
   if (handle.size != blob.size()) {

--- a/utilities/titandb/blob_file_size_collector_test.cc
+++ b/utilities/titandb/blob_file_size_collector_test.cc
@@ -41,7 +41,7 @@ class BlobFileSizeCollectorTest : public testing::Test {
     std::unique_ptr<WritableFile> writable_file;
     ASSERT_OK(env_->NewWritableFile(file_name_, &writable_file, env_options_));
     result->reset(
-        new WritableFileWriter(std::move(writable_file), env_options_));
+        new WritableFileWriter(std::move(writable_file), file_name_, env_options_));
     ASSERT_TRUE(*result);
   }
 

--- a/utilities/titandb/blob_file_test.cc
+++ b/utilities/titandb/blob_file_test.cc
@@ -31,7 +31,7 @@ class BlobFileTest : public testing::Test {
     {
       std::unique_ptr<WritableFile> f;
       ASSERT_OK(env_->NewWritableFile(file_name_, &f, env_options_));
-      file.reset(new WritableFileWriter(std::move(f), env_options_));
+      file.reset(new WritableFileWriter(std::move(f), file_name_, env_options_));
     }
     std::unique_ptr<BlobFileBuilder> builder(
         new BlobFileBuilder(cf_options, file.get()));
@@ -91,7 +91,7 @@ class BlobFileTest : public testing::Test {
     {
       std::unique_ptr<WritableFile> f;
       ASSERT_OK(env_->NewWritableFile(file_name_, &f, env_options_));
-      file.reset(new WritableFileWriter(std::move(f), env_options_));
+      file.reset(new WritableFileWriter(std::move(f), file_name_, env_options_));
     }
     std::unique_ptr<BlobFileBuilder> builder(
         new BlobFileBuilder(cf_options, file.get()));

--- a/utilities/titandb/db_impl.cc
+++ b/utilities/titandb/db_impl.cc
@@ -25,7 +25,7 @@ class TitanDBImpl::FileManager : public BlobFileManager {
       std::unique_ptr<WritableFile> f;
       s = db_->env_->NewWritableFile(name, &f, db_->env_options_);
       if (!s.ok()) return s;
-      file.reset(new WritableFileWriter(std::move(f), db_->env_options_));
+      file.reset(new WritableFileWriter(std::move(f), name, db_->env_options_));
     }
 
     handle->reset(new FileHandle(number, name, std::move(file)));

--- a/utilities/titandb/table_builder_test.cc
+++ b/utilities/titandb/table_builder_test.cc
@@ -24,7 +24,7 @@ class FileManager : public BlobFileManager {
       std::unique_ptr<WritableFile> f;
       Status s = env_->NewWritableFile(name, &f, env_options_);
       if (!s.ok()) return s;
-      file.reset(new WritableFileWriter(std::move(f), env_options_));
+      file.reset(new WritableFileWriter(std::move(f), name, env_options_));
     }
     handle->reset(new FileHandle(number, name, std::move(file)));
     return Status::OK();
@@ -102,7 +102,7 @@ class TableBuilderTest : public testing::Test {
                      std::unique_ptr<WritableFileWriter>* result) {
     std::unique_ptr<WritableFile> file;
     ASSERT_OK(env_->NewWritableFile(fname, &file, env_options_));
-    result->reset(new WritableFileWriter(std::move(file), env_options_));
+    result->reset(new WritableFileWriter(std::move(file), fname, env_options_));
   }
 
   void NewFileReader(const std::string& fname,

--- a/utilities/titandb/util.cc
+++ b/utilities/titandb/util.cc
@@ -81,7 +81,7 @@ Slice Compress(const CompressionContext& ctx, const Slice& input,
 Status Uncompress(const UncompressionContext& ctx, const Slice& input,
                   OwnedSlice* output) {
   int size = 0;
-  std::unique_ptr<char[]> ubuf;
+  CacheAllocationPtr ubuf;
   assert(ctx.type() != kNoCompression);
 
   switch (ctx.type()) {
@@ -98,32 +98,32 @@ Status Uncompress(const UncompressionContext& ctx, const Slice& input,
       break;
     }
     case kZlibCompression:
-      ubuf.reset(Zlib_Uncompress(ctx, input.data(), input.size(), &size,
-                                 kCompressionFormat));
+      ubuf = Zlib_Uncompress(ctx, input.data(), input.size(), &size,
+                             kCompressionFormat);
       if (!ubuf.get()) {
         return Status::Corruption("Corrupted compressed blob", "Zlib");
       }
       output->reset(std::move(ubuf), size);
       break;
     case kBZip2Compression:
-      ubuf.reset(BZip2_Uncompress(input.data(), input.size(), &size,
-                                  kCompressionFormat));
+      ubuf = BZip2_Uncompress(input.data(), input.size(), &size,
+                              kCompressionFormat);
       if (!ubuf.get()) {
         return Status::Corruption("Corrupted compressed blob", "Bzip2");
       }
       output->reset(std::move(ubuf), size);
       break;
     case kLZ4Compression:
-      ubuf.reset(LZ4_Uncompress(ctx, input.data(), input.size(), &size,
-                                kCompressionFormat));
+      ubuf = LZ4_Uncompress(ctx, input.data(), input.size(), &size,
+                            kCompressionFormat);
       if (!ubuf.get()) {
         return Status::Corruption("Corrupted compressed blob", "LZ4");
       }
       output->reset(std::move(ubuf), size);
       break;
     case kLZ4HCCompression:
-      ubuf.reset(LZ4_Uncompress(ctx, input.data(), input.size(), &size,
-                                kCompressionFormat));
+      ubuf = LZ4_Uncompress(ctx, input.data(), input.size(), &size,
+                            kCompressionFormat);
       if (!ubuf.get()) {
         return Status::Corruption("Corrupted compressed blob", "LZ4HC");
       }
@@ -138,7 +138,7 @@ Status Uncompress(const UncompressionContext& ctx, const Slice& input,
       break;
     case kZSTD:
     case kZSTDNotFinalCompression:
-      ubuf.reset(ZSTD_Uncompress(ctx, input.data(), input.size(), &size));
+      ubuf = ZSTD_Uncompress(ctx, input.data(), input.size(), &size);
       if (!ubuf.get()) {
         return Status::Corruption("Corrupted compressed blob", "ZSTD");
       }

--- a/utilities/titandb/util.h
+++ b/utilities/titandb/util.h
@@ -20,13 +20,13 @@ namespace titandb {
 // A slice pointed to an owned buffer.
 class OwnedSlice : public Slice {
  public:
-  void reset(std::unique_ptr<char[]> _data, size_t _size) {
+  void reset(CacheAllocationPtr _data, size_t _size) {
     data_ = _data.get();
     size_ = _size;
     buffer_ = std::move(_data);
   }
 
-  void reset(std::unique_ptr<char[]> buffer, const Slice& s) {
+  void reset(CacheAllocationPtr buffer, const Slice& s) {
     data_ = s.data();
     size_ = s.size();
     buffer_ = std::move(buffer);
@@ -43,7 +43,7 @@ class OwnedSlice : public Slice {
   }
 
  private:
-  std::unique_ptr<char[]> buffer_;
+  CacheAllocationPtr buffer_;
 };
 
 // A slice pointed to a fixed size buffer.

--- a/utilities/titandb/version_set.cc
+++ b/utilities/titandb/version_set.cc
@@ -144,7 +144,7 @@ Status VersionSet::OpenManifest(uint64_t file_number) {
     std::unique_ptr<WritableFile> f;
     s = env_->NewWritableFile(file_name, &f, env_options_);
     if (!s.ok()) return s;
-    file.reset(new WritableFileWriter(std::move(f), env_options_));
+    file.reset(new WritableFileWriter(std::move(f), file_name, env_options_));
   }
 
   manifest_.reset(new log::Writer(std::move(file), 0, false));


### PR DESCRIPTION
Summary:
Fix: compression util functions now return `CacheAllocationPtr`.
Fix: WritableFileWriter constructor now require file name.
Fix options.original_table_factory not ignored in options_settable_test.

Tested Plan:
Run `make all check titandb_check` locally

Signed-off-by: Yi Wu <yiwu@pingcap.com>