### PR TITLE
Titan: Fix iterator fail to pass SuperVersion to underlying iterator

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1154,7 +1154,8 @@ InternalIterator* DBImpl::NewInternalIterator(const ReadOptions& read_options,
                                               SuperVersion* super_version,
                                               Arena* arena,
                                               RangeDelAggregator* range_del_agg,
-                                              SequenceNumber sequence) {
+                                              SequenceNumber sequence,
+                                              bool is_user_sv) {
   InternalIterator* internal_iter;
   assert(arena != nullptr);
   assert(range_del_agg != nullptr);
@@ -1189,10 +1190,12 @@ InternalIterator* DBImpl::NewInternalIterator(const ReadOptions& read_options,
                                            &merge_iter_builder, range_del_agg);
     }
     internal_iter = merge_iter_builder.Finish();
-    IterState* cleanup =
-        new IterState(this, &mutex_, super_version,
-                      read_options.background_purge_on_iterator_cleanup);
-    internal_iter->RegisterCleanup(CleanupIteratorState, cleanup, nullptr);
+    if (!is_user_sv) {
+      IterState* cleanup =
+          new IterState(this, &mutex_, super_version,
+                        read_options.background_purge_on_iterator_cleanup);
+      internal_iter->RegisterCleanup(CleanupIteratorState, cleanup, nullptr);
+    }
 
     return internal_iter;
   } else {
@@ -1798,8 +1801,11 @@ ArenaWrappedDBIter* DBImpl::NewIteratorImpl(const ReadOptions& read_options,
                                             bool allow_blob,
                                             bool allow_refresh,
                                             SuperVersion* sv) {
+  bool is_user_sv = false;
   if (sv == nullptr) {
     sv = cfd->GetReferencedSuperVersion(&mutex_);
+  } else {
+    is_user_sv = true;
   }
 
   // Try to generate a DB iterator tree in continuous memory area to be
@@ -1852,7 +1858,7 @@ ArenaWrappedDBIter* DBImpl::NewIteratorImpl(const ReadOptions& read_options,
 
   InternalIterator* internal_iter =
       NewInternalIterator(read_options, cfd, sv, db_iter->GetArena(),
-                          db_iter->GetRangeDelAggregator(), snapshot);
+                          db_iter->GetRangeDelAggregator(), snapshot, is_user_sv);
   db_iter->SetIterUnderDBIter(internal_iter);
 
   return db_iter;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -583,7 +583,8 @@ class DBImpl : public DB {
 
   InternalIterator* NewInternalIterator(
       const ReadOptions&, ColumnFamilyData* cfd, SuperVersion* super_version,
-      Arena* arena, RangeDelAggregator* range_del_agg, SequenceNumber sequence);
+      Arena* arena, RangeDelAggregator* range_del_agg, SequenceNumber sequence,
+      bool is_user_sv = false);
 
   // hollow transactions shell used for recovery.
   // these will then be passed to TransactionDB so that

--- a/utilities/titandb/db_impl.cc
+++ b/utilities/titandb/db_impl.cc
@@ -414,7 +414,7 @@ Iterator* TitanDBImpl::NewIteratorImpl(
   }
   std::unique_ptr<ArenaWrappedDBIter> iter(db_impl_->NewIteratorImpl(
       options, cfd, snap->GetSequenceNumber(), nullptr /*read_callback*/,
-      true /*allow_blob*/, sv));
+      true /*allow_blob*/, true /*allow_refresh*/, sv));
   return new TitanDBIterator(options, storage.lock().get(), snapshot,
                              std::move(iter));
 }


### PR DESCRIPTION
Summary:
The `allow_refresh` param is missing when Titan create `DBIter`, and Titan end up passing nullptr as `super_version`. Fixing it. Also fix `TitanSnapshot` and `InternalIterator` double cleanup of `super_version`.

Test Plan:
`make titandb_check`