### PR TITLE
Titan: Add ReadAfterDropCF test

### DIFF
--- a/utilities/titandb/db_impl.cc
+++ b/utilities/titandb/db_impl.cc
@@ -265,6 +265,11 @@ Status TitanDBImpl::CreateColumnFamilies(
   return s;
 }
 
+Status TitanDBImpl::DropColumnFamily(
+    ColumnFamilyHandle* handle) {
+  return DropColumnFamilies({handle});
+}
+
 Status TitanDBImpl::DropColumnFamilies(
     const std::vector<ColumnFamilyHandle*>& handles) {
   std::vector<uint32_t> column_families;

--- a/utilities/titandb/db_impl.h
+++ b/utilities/titandb/db_impl.h
@@ -24,6 +24,7 @@ class TitanDBImpl : public TitanDB {
       const std::vector<TitanCFDescriptor>& descs,
       std::vector<ColumnFamilyHandle*>* handles) override;
 
+  Status DropColumnFamily(ColumnFamilyHandle* handle) override;
   Status DropColumnFamilies(
       const std::vector<ColumnFamilyHandle*>& handles) override;
 

--- a/utilities/titandb/titan_db_test.cc
+++ b/utilities/titandb/titan_db_test.cc
@@ -267,7 +267,7 @@ TEST_F(TitanDBTest, ReadAfterDropCF) {
   Flush();
   VerifyDB(data);
   for(auto& handle : cf_handles_) {
-    ASSERT_OK(db_->DropColumnFamily(cf_handles_.front()));
+    ASSERT_OK(db_->DropColumnFamily(handle));
     VerifyDB(data);
   }
 }

--- a/utilities/titandb/titan_db_test.cc
+++ b/utilities/titandb/titan_db_test.cc
@@ -252,6 +252,26 @@ TEST_F(TitanDBTest, Snapshot) {
     db_->ReleaseSnapshot(snapshot);
 }
 
+TEST_F(TitanDBTest, ReadAfterDropCF) {
+  Open();
+  const uint64_t kNumCF = 3;
+  for(uint64_t i = 1; i <= kNumCF; i++) {
+    AddCF(std::to_string(i));
+  }
+  const uint64_t kNumEntries = 100;
+  std::map<std::string, std::string> data;
+  for(uint64_t i = 1; i <= kNumEntries; i++) {
+    Put(i, &data);
+  }
+  VerifyDB(data);
+  Flush();
+  VerifyDB(data);
+  for(auto& handle : cf_handles_) {
+    ASSERT_OK(db_->DropColumnFamily(cf_handles_.front()));
+    VerifyDB(data);
+  }
+}
+
 }  // namespace titandb
 }  // namespace rocksdb
 

--- a/utilities/titandb/titan_db_test.cc
+++ b/utilities/titandb/titan_db_test.cc
@@ -252,7 +252,7 @@ TEST_F(TitanDBTest, Snapshot) {
     db_->ReleaseSnapshot(snapshot);
 }
 
-TEST_F(TitanDBTest, ReadAfterDropCF) {
+TEST_F(TitanDBTest, DISABLED_ReadAfterDropCF) {
   Open();
   const uint64_t kNumCF = 3;
   for(uint64_t i = 1; i <= kNumCF; i++) {


### PR DESCRIPTION
* fix missing DropColumnFamily method
* add test for API behaviour of DropColumnFamily: outstanding CF handle should be able to read after it's dropped.

it will raise `GetSuperVersion failed` panic for now.
this broken test should be resolved by reserving ColumnFamilyData after drop, and reserving Blob file after drop.