### PR TITLE
Titan: remove DropColumnFamily override

### DIFF
--- a/utilities/titandb/db_impl.cc
+++ b/utilities/titandb/db_impl.cc
@@ -265,11 +265,6 @@ Status TitanDBImpl::CreateColumnFamilies(
   return s;
 }
 
-Status TitanDBImpl::DropColumnFamily(
-    ColumnFamilyHandle* handle) {
-  return DropColumnFamilies({handle});
-}
-
 Status TitanDBImpl::DropColumnFamilies(
     const std::vector<ColumnFamilyHandle*>& handles) {
   std::vector<uint32_t> column_families;

--- a/utilities/titandb/db_impl.h
+++ b/utilities/titandb/db_impl.h
@@ -24,7 +24,6 @@ class TitanDBImpl : public TitanDB {
       const std::vector<TitanCFDescriptor>& descs,
       std::vector<ColumnFamilyHandle*>* handles) override;
 
-  Status DropColumnFamily(ColumnFamilyHandle* handle) override;
   Status DropColumnFamilies(
       const std::vector<ColumnFamilyHandle*>& handles) override;
 


### PR DESCRIPTION
Found existing implementation for `DropColumnFamily` in `rocksdb/utilities/titandb/db.h`,
therefore revert redundant updates to TitanDBImpl as an amendment to #87. 