### PR TITLE
Titan: Remove DBOptions::orignal_table_factory

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -278,7 +278,6 @@ struct ColumnFamilyOptions : public AdvancedColumnFamilyOptions {
   // implementation of TableBuilder and TableReader with default
   // BlockBasedTableOptions.
   std::shared_ptr<TableFactory> table_factory;
-  std::shared_ptr<TableFactory> original_table_factory{nullptr};
 
   // A list of paths where SST files for this column family
   // can be put into, with its target size. Similar to db_paths,

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -48,9 +48,6 @@ ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
       db_paths(db_options.db_paths),
       memtable_factory(cf_options.memtable_factory.get()),
       table_factory(cf_options.table_factory.get()),
-      original_table_factory(cf_options.original_table_factory
-                                 ? cf_options.original_table_factory.get()
-                                 : nullptr),
       table_properties_collector_factories(
           cf_options.table_properties_collector_factories),
       advise_random_on_open(db_options.advise_random_on_open),

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -71,7 +71,6 @@ struct ImmutableCFOptions {
   MemTableRepFactory* memtable_factory;
 
   TableFactory* table_factory;
-  TableFactory* original_table_factory{nullptr};
 
   Options::TablePropertiesCollectorFactories
       table_properties_collector_factories;

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -349,8 +349,6 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
        sizeof(std::shared_ptr<const SliceTransform>)},
       {offset_of(&ColumnFamilyOptions::table_factory),
        sizeof(std::shared_ptr<TableFactory>)},
-      {offset_of(&ColumnFamilyOptions::original_table_factory),
-       sizeof(std::shared_ptr<TableFactory>)},
       {offset_of(&ColumnFamilyOptions::cf_paths),
        sizeof(std::vector<DbPath>)},
   };

--- a/table/sst_file_writer.cc
+++ b/table/sst_file_writer.cc
@@ -243,13 +243,8 @@ Status SstFileWriter::Open(const std::string& file_path) {
 
   // TODO(tec) : If table_factory is using compressed block cache, we will
   // be adding the external sst file blocks into it, which is wasteful.
-  if (r->ioptions.original_table_factory) {
-    r->builder.reset(r->ioptions.original_table_factory->NewTableBuilder(
-        table_builder_options, cf_id, r->file_writer.get()));
-  } else {
-    r->builder.reset(r->ioptions.table_factory->NewTableBuilder(
-        table_builder_options, cf_id, r->file_writer.get()));
-  }
+  r->builder.reset(r->ioptions.table_factory->NewTableBuilder(
+      table_builder_options, cf_id, r->file_writer.get()));
 
   r->file_info = ExternalSstFileInfo();
   r->file_info.file_path = file_path;

--- a/utilities/titandb/db_impl.h
+++ b/utilities/titandb/db_impl.h
@@ -60,6 +60,9 @@ class TitanDBImpl : public TitanDB {
 
   void ReleaseSnapshot(const Snapshot* snapshot) override;
 
+  using TitanDB::GetOptions;
+  Options GetOptions(ColumnFamilyHandle* column_family) const override;
+
   void OnFlushCompleted(const FlushJobInfo& flush_job_info);
 
   void OnCompactionCompleted(const CompactionJobInfo& compaction_job_info);
@@ -122,6 +125,8 @@ class TitanDBImpl : public TitanDB {
   EnvOptions env_options_;
   DBImpl* db_impl_;
   TitanDBOptions db_options_;
+  std::unordered_map<uint32_t, std::shared_ptr<TableFactory>>
+      original_table_factory_;
 
   std::unique_ptr<VersionSet> vset_;
   std::set<uint64_t> pending_outputs_;

--- a/utilities/titandb/titan_db_test.cc
+++ b/utilities/titandb/titan_db_test.cc
@@ -214,21 +214,11 @@ class TitanDBTest : public testing::Test {
     auto db_options = db->GetDBOptions();
     ImmutableCFOptions immu_cf_options(ImmutableDBOptions(db_options),
                                        cf_options);
-    ASSERT_EQ(original_table_factory, immu_cf_options.original_table_factory);
-    ASSERT_NE(original_table_factory, immu_cf_options.table_factory);
+    ASSERT_EQ(original_table_factory, immu_cf_options.table_factory);
     ASSERT_OK(db->Close());
 
     DeleteDir(env_, options_.dirname);
     DeleteDir(env_, dbname_);
-    DB* db2;
-    ASSERT_OK(DB::Open(options, dbname_, &db2));
-    auto cf_options2 = db2->GetOptions(db2->DefaultColumnFamily());
-    auto db_options2 = db2->GetDBOptions();
-    ImmutableCFOptions immu_cf_options2(ImmutableDBOptions(db_options2),
-                                        cf_options2);
-    ASSERT_EQ(nullptr, immu_cf_options2.original_table_factory);
-    ASSERT_EQ(original_table_factory, immu_cf_options2.table_factory);
-    ASSERT_OK(db2->Close());
   }
 
   Env* env_{Env::Default()};


### PR DESCRIPTION
Summary:
This is to remove intrusive change to core rocksdb. The `original_table_factory` option was added so that `SstFileWriter` can use `BlockBasedTableFactory` instead of `TitanTableFactory` to generate sst file. We now return original table factory through `GetOptions()` API and user can pass it back to `SstTableWriter`.

Test Plan:
Updated test.