### PR TITLE
Titan: Add blob file header

### DIFF
--- a/utilities/titandb/blob_file_builder.cc
+++ b/utilities/titandb/blob_file_builder.cc
@@ -3,6 +3,15 @@
 namespace rocksdb {
 namespace titandb {
 
+BlobFileBuilder::BlobFileBuilder(const TitanCFOptions& options,
+                                 WritableFileWriter* file)
+    : options_(options), file_(file), encoder_(options_.blob_file_compression) {
+  BlobFileHeader header;
+  std::string buffer;
+  header.EncodeTo(&buffer);
+  status_ = file_->Append(buffer);
+}
+
 void BlobFileBuilder::Add(const BlobRecord& record, BlobHandle* handle) {
   if (!ok()) return;
 

--- a/utilities/titandb/blob_file_builder.h
+++ b/utilities/titandb/blob_file_builder.h
@@ -36,10 +36,7 @@ class BlobFileBuilder {
   // Constructs a builder that will store the contents of the file it
   // is building in "*file". Does not close the file. It is up to the
   // caller to sync and close the file after calling Finish().
-  BlobFileBuilder(const TitanCFOptions& options, WritableFileWriter* file)
-      : options_(options),
-        file_(file),
-        encoder_(options_.blob_file_compression) {}
+  BlobFileBuilder(const TitanCFOptions& options, WritableFileWriter* file);
 
   // Adds the record to the file and points the handle to it.
   void Add(const BlobRecord& record, BlobHandle* handle);

--- a/utilities/titandb/blob_file_iterator.cc
+++ b/utilities/titandb/blob_file_iterator.cc
@@ -17,10 +17,20 @@ BlobFileIterator::BlobFileIterator(
 BlobFileIterator::~BlobFileIterator() {}
 
 bool BlobFileIterator::Init() {
-  char buf[BlobFileFooter::kEncodedLength];
   Slice slice;
+  char header_buf[BlobFileHeader::kEncodedLength];
+  status_ = file_->Read(0, BlobFileHeader::kEncodedLength, &slice, header_buf);
+  if (!status_.ok()) {
+    return false;
+  }
+  BlobFileHeader blob_file_header;
+  status_ = blob_file_header.DecodeFrom(&slice);
+  if (!status_.ok()) {
+    return false;
+  }
+  char footer_buf[BlobFileFooter::kEncodedLength];
   status_ = file_->Read(file_size_ - BlobFileFooter::kEncodedLength,
-                        BlobFileFooter::kEncodedLength, &slice, buf);
+                        BlobFileFooter::kEncodedLength, &slice, footer_buf);
   if (!status_.ok()) return false;
   BlobFileFooter blob_file_footer;
   status_ = blob_file_footer.DecodeFrom(&slice);

--- a/utilities/titandb/blob_file_iterator.h
+++ b/utilities/titandb/blob_file_iterator.h
@@ -50,7 +50,7 @@ class BlobFileIterator {
   TitanCFOptions titan_cf_options_;
 
   bool init_{false};
-  uint64_t total_blocks_size_{0};
+  uint64_t end_of_blob_record_{0};
 
   // Iterator status
   Status status_;

--- a/utilities/titandb/blob_format.cc
+++ b/utilities/titandb/blob_format.cc
@@ -196,12 +196,29 @@ double BlobFileMeta::GetDiscardableRatio() const {
          static_cast<double>(file_size_);
 }
 
+void BlobFileHeader::EncodeTo(std::string* dst) const {
+  PutFixed32(dst, kHeaderMagicNumber);
+  PutFixed32(dst, version);
+}
+
+Status BlobFileHeader::DecodeFrom(Slice* src) {
+  uint32_t magic_number = 0;
+  if (!GetFixed32(src, &magic_number) || magic_number != kHeaderMagicNumber) {
+    return Status::Corruption(
+        "Blob file header magic number missing or mismatched.");
+  }
+  if (!GetFixed32(src, &version) || version != kVersion1) {
+    return Status::Corruption("Blob file header version missing or invalid.");
+  }
+  return Status::OK();
+}
+
 void BlobFileFooter::EncodeTo(std::string* dst) const {
   auto size = dst->size();
   meta_index_handle.EncodeTo(dst);
   // Add padding to make a fixed size footer.
   dst->resize(size + kEncodedLength - 12);
-  PutFixed64(dst, kMagicNumber);
+  PutFixed64(dst, kFooterMagicNumber);
   Slice encoded(dst->data() + size, dst->size() - size);
   PutFixed32(dst, crc32c::Value(encoded.data(), encoded.size()));
 }
@@ -215,7 +232,7 @@ Status BlobFileFooter::DecodeFrom(Slice* src) {
   // Remove padding.
   src->remove_prefix(data + kEncodedLength - 12 - src->data());
   uint64_t magic_number = 0;
-  if (!GetFixed64(src, &magic_number) || magic_number != kMagicNumber) {
+  if (!GetFixed64(src, &magic_number) || magic_number != kFooterMagicNumber) {
     return Status::Corruption("BlobFileFooter", "magic number");
   }
   Slice decoded(data, src->data() - data);

--- a/utilities/titandb/blob_format.h
+++ b/utilities/titandb/blob_format.h
@@ -151,6 +151,24 @@ class BlobFileMeta {
   //  bool marked_for_gc_{false};
 };
 
+// Blob file header format.
+// The header is mean to be compatible with header of BlobDB blob files, except
+// we use a different magic number.
+//
+// magic_number         : fixed32
+// version              : fixed32
+struct BlobFileHeader {
+  // The first 32bits from $(echo titandb/blob | sha1sum).
+  static const uint32_t kHeaderMagicNumber = 0x2be0a614ul;
+  static const uint32_t kVersion1 = 1;
+  static const uint64_t kEncodedLength = 4 + 4;
+
+  uint32_t version = kVersion1;
+
+  void EncodeTo(std::string* dst) const;
+  Status DecodeFrom(Slice* src);
+};
+
 // Blob file footer format:
 //
 // meta_index_handle    : varint64 offset + varint64 size
@@ -159,7 +177,7 @@ class BlobFileMeta {
 // checksum             : fixed32
 struct BlobFileFooter {
   // The first 64bits from $(echo titandb/blob | sha1sum).
-  static const uint64_t kMagicNumber{0xcd3f52ea0fe14511ull};
+  static const uint64_t kFooterMagicNumber{0x2be0a6148e39edc6ull};
   static const uint64_t kEncodedLength{BlockHandle::kMaxEncodedLength + 8 + 4};
 
   BlockHandle meta_index_handle{BlockHandle::NullBlockHandle()};

--- a/utilities/titandb/blob_gc_job_test.cc
+++ b/utilities/titandb/blob_gc_job_test.cc
@@ -80,6 +80,7 @@ class BlobGCJobTest : public testing::Test {
     TitanCFOptions cf_options;
     LogBuffer log_buffer(InfoLogLevel::INFO_LEVEL, db_options.info_log.get());
     cf_options.min_gc_batch_size = 0;
+    cf_options.blob_file_discardable_ratio = 0.4;
 
     std::unique_ptr<BlobGC> blob_gc;
     {


### PR DESCRIPTION
Summary:
Adding 4 bytes magic number and 4 bytes version as header of blob files. This is same as the first 8 bytes of blob files of BlobDB. Benefits:
* Enable us to update file format later on.
* It will make us easier to distinguish our blob file and BlobDB blob file, if we will later merge into upstream.

Test Plan:
Existing tests