### PR TITLE
Titan: fix crash on recover when obsolete file exists

### DIFF
--- a/utilities/titandb/version_set.cc
+++ b/utilities/titandb/version_set.cc
@@ -107,11 +107,10 @@ Status VersionSet::Recover() {
       if (f.second->is_obsolete()) {
         // delete already obsoleted files at reopen
         obsolete_files.push_back(f.second->file_number());
-        for (auto it = obsolete_files_.blob_files.begin(); it != obsolete_files_.blob_files.end();) {
+        for (auto it = obsolete_files_.blob_files.begin(); it != obsolete_files_.blob_files.end(); ++it) {
           if (std::get<0>(*it) == f.second->file_number())  {
             it = this->obsolete_files_.blob_files.erase(it);
-          } else {
-            ++it;
+            break;
           }
         }
       } else {

--- a/utilities/titandb/version_set.cc
+++ b/utilities/titandb/version_set.cc
@@ -2,7 +2,7 @@
 
 #include <inttypes.h>
 
-#include "util/testharness.h"
+#include "util/autovector.h"
 #include "util/filename.h"
 
 namespace rocksdb {
@@ -101,19 +101,25 @@ Status VersionSet::Recover() {
   // Purge inactive files at start
   std::set<uint64_t> alive_files;
   alive_files.insert(new_manifest_file_number);
-  for (const auto& bs : this->column_families_) {
-    for (const auto& f : bs.second->files_) {
+  for (const auto& bs : column_families_) {
+    autovector<uint64_t> obsolete_files;
+     for (const auto& f : bs.second->files_) {
       if (f.second->is_obsolete()) {
         // delete already obsoleted files at reopen
-        bs.second->DeleteBlobFile(f.second->file_number());
-        for (auto it = this->obsolete_files_.blob_files.begin(); it != this->obsolete_files_.blob_files.end(); ++it) {
+        obsolete_files.push_back(f.second->file_number());
+        for (auto it = obsolete_files_.blob_files.begin(); it != obsolete_files_.blob_files.end();) {
           if (std::get<0>(*it) == f.second->file_number())  {
-            this->obsolete_files_.blob_files.erase(it);
+            it = this->obsolete_files_.blob_files.erase(it);
+          } else {
+            ++it;
           }
         }
       } else {
         alive_files.insert(f.second->file_number());
       }
+    }
+    for (uint64_t obsolete_file : obsolete_files) {
+      bs.second->DeleteBlobFile(obsolete_file);
     }
   }
   std::vector<std::string> files;


### PR DESCRIPTION
Summary:
Fixing two issues to lead to crash if obsolete files detected on recovery:
1. `obsolete_files_` is a `std::list` and its iterator will be invalidate after erasing an item from the list. Use the return value from `erase()` to continue iterate.
2. Similarly, `BlobStorage::files_` should not be modify while iterating. Move `DeleteBlobFile` logic out of the loop of checking for obsolte files.

Test Plan:
`TitanDBTest::Basic` was failing on my side as it triggered a GC and obsolete some files before restart. Make sure it is passing now.

Signed-off-by: Yi Wu <yiwu@pingcap.com>