### PR TITLE
Titan: Fix iterator retrying and add seek related test

### DIFF
--- a/utilities/titandb/db_iter.h
+++ b/utilities/titandb/db_iter.h
@@ -59,53 +59,44 @@ class TitanDBIterator : public Iterator {
   bool Valid() const override { return iter_->Valid() && status_.ok(); }
 
   Status status() const override {
-    Status s = iter_->status();
-    if (s.ok()) s = status_;
-    return s;
+    // assume volatile inner iter
+    if(status_.ok()) {
+      return iter_->status();
+    } else {
+      return status_;
+    }
   }
 
   void SeekToFirst() override {
     iter_->SeekToFirst();
-    while (!GetBlobValue()) {
-      iter_->Next();
-    }
+    GetBlobValue();
   }
 
   void SeekToLast() override {
     iter_->SeekToLast();
-    while (!GetBlobValue()) {
-      iter_->Prev();
-    }
+    GetBlobValue();
   }
 
   void Seek(const Slice& target) override {
     iter_->Seek(target);
-    while (!GetBlobValue()) {
-      iter_->Next();
-    }
+    GetBlobValue();
   }
 
   void SeekForPrev(const Slice& target) override {
     iter_->SeekForPrev(target);
-    while (!GetBlobValue()) {
-      iter_->Prev();
-    }
+    GetBlobValue();
   }
 
   void Next() override {
     assert(Valid());
     iter_->Next();
-    while (!GetBlobValue()) {
-      iter_->Next();
-    }
+    GetBlobValue();
   }
 
   void Prev() override {
     assert(Valid());
     iter_->Prev();
-    while (!GetBlobValue()) {
-      iter_->Prev();
-    }
+    GetBlobValue();
   }
 
   Slice key() const override {
@@ -120,11 +111,10 @@ class TitanDBIterator : public Iterator {
   }
 
  private:
-  // return value: false means key has been deleted, we need to skipped it.
-  bool GetBlobValue() {
+  void GetBlobValue() {
     if (!iter_->Valid() || !iter_->IsBlob()) {
       status_ = iter_->status();
-      return true;
+      return;
     }
     assert(iter_->status().ok());
 
@@ -146,13 +136,12 @@ class TitanDBIterator : public Iterator {
                 iter_->key().ToString(true).c_str(), status_.ToString().c_str(),
                 options_.snapshot->GetSequenceNumber());
       }
-      if (!status_.ok()) return true;
+      if (!status_.ok()) return;
       it = files_.emplace(index.file_number, std::move(prefetcher)).first;
     }
 
     buffer_.Reset();
     status_ = it->second->Get(options_, index.blob_handle, &record_, &buffer_);
-    return true;
   }
 
   Status status_;

--- a/utilities/titandb/titan_db_test.cc
+++ b/utilities/titandb/titan_db_test.cc
@@ -273,6 +273,40 @@ TEST_F(TitanDBTest, DbIter) {
   ASSERT_FALSE(iter->Valid());
 }
 
+TEST_F(TitanDBTest, DBIterSeek) {
+  Open();
+  std::map<std::string, std::string> data;
+  const int kNumEntries = 100;
+  for (uint64_t i = 1; i <= kNumEntries; i++) {
+    Put(i, &data);
+  }
+  ASSERT_EQ(kNumEntries, data.size());
+  std::unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+  iter->SeekToFirst();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(data.begin()->first, iter->key());
+  ASSERT_EQ(data.begin()->second, iter->value());
+  iter->SeekToLast();
+  ASSERT_EQ(data.rbegin()->first, iter->key());
+  ASSERT_EQ(data.rbegin()->second, iter->value());
+  for (auto it = data.rbegin(); it != data.rend(); it++) {
+    iter->SeekToLast();
+    ASSERT_TRUE(iter->Valid());
+    iter->SeekForPrev(it->first);
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(it->first, iter->key());
+    ASSERT_EQ(it->second, iter->value());
+  }
+  for (const auto& it : data) {
+    iter->SeekToFirst();
+    ASSERT_TRUE(iter->Valid());
+    iter->Seek(it.first);
+    ASSERT_TRUE(iter->Valid());
+    ASSERT_EQ(it.first, iter->key());
+    ASSERT_EQ(it.second, iter->value());
+  }
+}
+
 TEST_F(TitanDBTest, Snapshot) {
   Open();
   std::map<std::string, std::string> data;


### PR DESCRIPTION
As a follow-up PR on #91, fix the obselete while-loop and status check in `TitanDBIterator`.
Also add `DBIterSeek` unit test to cover all seek methods iterator provides.