### PR TITLE
Fix -Wdeprecated-copy GCC 9 warnings

### DIFF
--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -232,6 +232,26 @@ class InternalStats {
       }
     }
 
+    CompactionStats & operator=(const CompactionStats& c) {
+      count = c.count;
+      micros = c.micros;
+      bytes_read_non_output_levels = c.bytes_read_non_output_levels;
+      bytes_read_output_level = c.bytes_read_output_level;
+      bytes_written = c.bytes_written;
+      bytes_moved = c.bytes_moved;
+      num_input_files_in_non_output_levels =
+        c.num_input_files_in_non_output_levels;
+      num_input_files_in_output_level = c.num_input_files_in_output_level;
+      num_output_files = c.num_output_files;
+      num_input_records = c.num_input_records;
+      num_dropped_records = c.num_dropped_records;
+      int num_of_reasons = static_cast<int>(CompactionReason::kNumOfReasons);
+      for (int i = 0; i < num_of_reasons; i++) {
+        counts[i] = c.counts[i];
+      }
+      return *this;
+    }
+
     void Clear() {
       this->micros = 0;
       this->bytes_read_non_output_levels = 0;

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -52,6 +52,14 @@ struct FileDescriptor {
         smallest_seqno(_smallest_seqno),
         largest_seqno(_largest_seqno) {}
 
+  FileDescriptor(const FileDescriptor& fd) {
+    table_reader = fd.table_reader;
+    packed_number_and_path_id = fd.packed_number_and_path_id;
+    file_size = fd.file_size;
+    smallest_seqno = fd.smallest_seqno;
+    largest_seqno = fd.largest_seqno;
+  }
+
   FileDescriptor& operator=(const FileDescriptor& fd) {
     table_reader = fd.table_reader;
     packed_number_and_path_id = fd.packed_number_and_path_id;

--- a/utilities/persistent_cache/persistent_cache_util.h
+++ b/utilities/persistent_cache/persistent_cache_util.h
@@ -48,7 +48,7 @@ class BoundedQueue {
     T t = std::move(q_.front());
     size_ -= t.Size();
     q_.pop_front();
-    return std::move(t);
+    return t;
   }
 
   size_t Size() const {


### PR DESCRIPTION
This PR borrows the changes from https://github.com/facebook/rocksdb/pull/5426 and will fix rocksdb built failure on gcc 9.1

Fix https://github.com/tikv/tikv/issues/5034

Also affected https://github.com/pingcap/rust-rocksdb