### PR TITLE
Fix info log source file display length

### DIFF
--- a/logging/logging.h
+++ b/logging/logging.h
@@ -19,9 +19,9 @@
 
 inline const char* RocksLogShorterFileName(const char* file)
 {
-  // 15 is the length of "logging/logging.h".
+  // 18 is the length of "logging/logging.h".
   // If the name of this file changed, please change this number, too.
-  return file + (sizeof(__FILE__) > 15 ? sizeof(__FILE__) - 15 : 0);
+  return file + (sizeof(__FILE__) > 18 ? sizeof(__FILE__) - 18 : 0);
 }
 
 // Don't inclide file/line info in HEADER level


### PR DESCRIPTION
Summary:
Source code path in info log is not truncated to the correct length. Fixing it. 

Test Plan:
Build and run db_bench. Before:
```
2019/09/18-21:32:34.631181 7fdd42df6700 [_impl/db_impl_write.cc:1654] [default] New memtable created with log file: #9. Immutable memtables: 0.
```
After:
```
2019/09/18-21:36:09.226532 7f141b5f6700 [/db_impl/db_impl_write.cc:1654] [default] New memtable created with log file: #9. Immutable memtables: 0.
```