### PR TITLE
Disable Intra-L0 compaction

### DIFF
--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1524,19 +1524,9 @@ bool LevelCompactionBuilder::PickFileToCompact() {
 }
 
 bool LevelCompactionBuilder::PickIntraL0Compaction() {
-  start_level_inputs_.clear();
-  const std::vector<FileMetaData*>& level_files =
-      vstorage_->LevelFiles(0 /* level */);
-  if (level_files.size() <
-          static_cast<size_t>(
-              mutable_cf_options_.level0_file_num_compaction_trigger + 2) ||
-      level_files[0]->being_compacted) {
-    // If L0 isn't accumulating much files beyond the regular trigger, don't
-    // resort to L0->L0 compaction yet.
-    return false;
-  }
-  return FindIntraL0Compaction(level_files, kMinFilesForIntraL0Compaction,
-                               port::kMaxUint64, &start_level_inputs_);
+  // Temporarily disable intra-L0 compaction to avoid data corruption issue:
+  // https://github.com/facebook/rocksdb/issues/5913
+  return false;
 }
 }  // namespace
 

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -3063,7 +3063,7 @@ TEST_P(DBCompactionTestWithParam, ForceBottommostLevelCompaction) {
   rocksdb::SyncPoint::GetInstance()->DisableProcessing();
 }
 
-TEST_P(DBCompactionTestWithParam, IntraL0Compaction) {
+TEST_P(DBCompactionTestWithParam, DISABLED_IntraL0Compaction) {
   Options options = CurrentOptions();
   options.compression = kNoCompression;
   options.level0_file_num_compaction_trigger = 5;
@@ -3115,7 +3115,7 @@ TEST_P(DBCompactionTestWithParam, IntraL0Compaction) {
   }
 }
 
-TEST_P(DBCompactionTestWithParam, IntraL0CompactionDoesNotObsoleteDeletions) {
+TEST_P(DBCompactionTestWithParam, DISABLED_IntraL0CompactionDoesNotObsoleteDeletions) {
   // regression test for issue #2722: L0->L0 compaction can resurrect deleted
   // keys from older L0 files if L1+ files' key-ranges do not include the key.
   Options options = CurrentOptions();


### PR DESCRIPTION
Summary:
Temporarily disable intra-L0 compaction to avoid data corruption issue caused by intra-L0 compaction compacting ingested file and place the result at wrong position in L0.

Test Plan:
The disabled intra-L0 tests will fail with the change.